### PR TITLE
suppress "uninitialized" warning for msan_fuzz_test

### DIFF
--- a/examples/BUILD
+++ b/examples/BUILD
@@ -41,6 +41,7 @@ cc_fuzz_test(
 cc_fuzz_test(
     name = "msan_fuzz_test",
     srcs = ["msan_fuzz_test.cc"],
+    copts = ["-Wno-uninitialized"],
 )
 
 cc_fuzz_test(

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -38,6 +38,7 @@ cc_fuzz_test(
     srcs = ["hang_fuzz_test.cc"],
 )
 
+# This test is designed to trigger an uninitialized memory issue
 cc_fuzz_test(
     name = "msan_fuzz_test",
     srcs = ["msan_fuzz_test.cc"],


### PR DESCRIPTION
Fixes #25 