### PR TITLE
Initial version of the Python launcher script for invoking fuzz target executables

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,3 +12,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+    name = "rules_python",
+    url = "https://github.com/bazelbuild/rules_python/releases/download/0.0.2/rules_python-0.0.2.tar.gz",
+    strip_prefix = "rules_python-0.0.2",
+    sha256 = "b5668cde8bb6e3515057ef465a35ad712214962f0b3a314e551204266c7be90c",
+)
+load("@rules_python//python:repositories.bzl", "py_repositories")
+py_repositories()

--- a/fuzzing/tools/BUILD
+++ b/fuzzing/tools/BUILD
@@ -12,3 +12,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# This package contains tool scripts
+
+load("@rules_python//python:defs.bzl", "py_binary")
+
+py_binary(
+    name = "launcher",
+    srcs = ["launcher.py"],
+)

--- a/fuzzing/tools/BUILD
+++ b/fuzzing/tools/BUILD
@@ -20,4 +20,5 @@ load("@rules_python//python:defs.bzl", "py_binary")
 py_binary(
     name = "launcher",
     srcs = ["launcher.py"],
+    visibility = ["//visibility:public"],
 )

--- a/fuzzing/tools/launcher.py
+++ b/fuzzing/tools/launcher.py
@@ -5,14 +5,12 @@ This is the launcher script to provide a uniform command line interface behind a
 
 from absl import app
 from absl import flags
-from subprocess import call, TimeoutExpired
+from subprocess import call, TimeoutExpired, STDOUT
 import os
 
 FLAGS = flags.FLAGS
 
 flags.DEFINE_integer('timeout', 20, 'test timeout.', lower_bound=0)
-flags.DEFINE_enum('engine', 'libfuzzer', ['libfuzzer'],
-                  'the fuzzing engine used to do fuzzing test.')
 
 
 def main(argv):
@@ -20,10 +18,9 @@ def main(argv):
         raise app.UsageError("Too few arguments")
 
     ret_code = 0
-    cwd = os.getcwd()
     try:
         # Is this the right way to execute the runnable?
-        ret_code = call(cwd + "/../../../" + argv[1], timeout=FLAGS.timeout)
+        ret_code = call(argv[1], timeout=FLAGS.timeout)
     except TimeoutExpired as e:
         print("Error: Timeout")
     except Exception as e:

--- a/fuzzing/tools/launcher.py
+++ b/fuzzing/tools/launcher.py
@@ -10,16 +10,20 @@ import os
 
 FLAGS = flags.FLAGS
 
-flags.DEFINE_integer('timeout', 20, 'test timeout.', lower_bound=0)
+flags.DEFINE_integer(
+    'timeout_secs',
+    20,
+    'The maximum duration, in seconds, of the fuzzer run launched.',
+    lower_bound=0)
 
 
 def main(argv):
     if len(argv) != 2:
         raise app.UsageError(
-            "This script receives 2 arguments. It should look like:" +
-            "\n\tpython " + __file__ + " EXECUTABLE --timout=TIMEOUT")
+            "This script receives 1 argument. It should look like:" +
+            "\n\tpython " + __file__ + " EXECUTABLE")
 
-    os.execl(argv[1], argv[1], "-timeout=" + str(FLAGS.timeout))
+    os.execl(argv[1], argv[1], "-timeout=" + str(FLAGS.timeout_secs))
 
 
 if __name__ == '__main__':

--- a/fuzzing/tools/launcher.py
+++ b/fuzzing/tools/launcher.py
@@ -1,0 +1,36 @@
+# Lint as: python3
+"""
+This is the launcher script to provide a uniform command line interface behind a number of arbitrary fuzzing engines.
+"""
+
+from absl import app
+from absl import flags
+from subprocess import call, TimeoutExpired
+import os
+
+FLAGS = flags.FLAGS
+
+flags.DEFINE_integer('timeout', 20, 'test timeout.', lower_bound=0)
+flags.DEFINE_enum('engine', 'libfuzzer', ['libfuzzer'],
+                  'the fuzzing engine used to do fuzzing test.')
+
+
+def main(argv):
+    if len(argv) < 2:
+        raise app.UsageError("Too few arguments")
+
+    ret_code = 0
+    cwd = os.getcwd()
+    try:
+        # Is this the right way to execute the runnable?
+        ret_code = call(cwd + "/../../../" + argv[1], timeout=FLAGS.timeout)
+    except TimeoutExpired as e:
+        print("Error: Timeout")
+    except Exception as e:
+        print("Error: " + str(e))
+    if ret_code:
+        print("Error: " + str(ret_code))
+
+
+if __name__ == '__main__':
+    app.run(main)

--- a/fuzzing/tools/launcher.py
+++ b/fuzzing/tools/launcher.py
@@ -1,11 +1,11 @@
 # Lint as: python3
 """
-This is the launcher script to provide a uniform command line interface behind a number of arbitrary fuzzing engines.
+This is the launcher script to provide a uniform command line interface 
+behind a number of arbitrary fuzzing engines.
 """
 
 from absl import app
 from absl import flags
-from subprocess import call, TimeoutExpired, STDOUT
 import os
 
 FLAGS = flags.FLAGS
@@ -14,19 +14,12 @@ flags.DEFINE_integer('timeout', 20, 'test timeout.', lower_bound=0)
 
 
 def main(argv):
-    if len(argv) < 2:
-        raise app.UsageError("Too few arguments")
+    if len(argv) != 2:
+        raise app.UsageError(
+            "This script receives 2 arguments. It should look like:" +
+            "\n\tpython " + __file__ + " EXECUTABLE --timout=TIMEOUT")
 
-    ret_code = 0
-    try:
-        # Is this the right way to execute the runnable?
-        ret_code = call(argv[1], timeout=FLAGS.timeout)
-    except TimeoutExpired as e:
-        print("Error: Timeout")
-    except Exception as e:
-        print("Error: " + str(e))
-    if ret_code:
-        print("Error: " + str(ret_code))
+    os.execl(argv[1], argv[1], "-timeout=" + str(FLAGS.timeout))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #17 

This script aims at providing an uniform command line interface behind a number of arbitrary fuzzing engines. For now the script perform a plain fuzzing run with a given timeout.  

The command to use this script looks like
```
bazel run --config=asan-libfuzzer //examples:empty_fuzz_test --run_under='//fuzzing/tools:launcher --timeout=5'
```