### PR TITLE
Add -max_total_time argument into launcher.py

### DIFF
--- a/fuzzing/tools/launcher.py
+++ b/fuzzing/tools/launcher.py
@@ -23,7 +23,10 @@ def main(argv):
             "This script receives 1 argument. It should look like:" +
             "\n\tpython " + __file__ + " EXECUTABLE")
 
-    os.execl(argv[1], argv[1], "-timeout=" + str(FLAGS.timeout_secs))
+    os.execv(argv[1], [
+        argv[1], "-max_total_time=" + str(FLAGS.timeout_secs),
+        "-timeout=" + str(FLAGS.timeout_secs)
+    ])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Commit Message:**
Add -max_total_time argument into launcher.py
**Additional Description:**
The launcher script only pass -timeout, which set a timer for a single
fuzzing test loop, but that doesn't work for the overall fuzzing test.
Add -max_total_time to fix this problem.

The discussion about this problem can found in https://github.com/googleinterns/bazel-rules-fuzzing/pull/34#issuecomment-658982939
**Testing:**
CI testing and local testing.
**Docs Changes:** N/A
	
modified:   fuzzing/tools/launcher.py

Signed-off-by: tengpeng <tengpeng.li2020@gmail.com>