### PR TITLE
Rule fuzzing_corpus for collecting corpus files

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -22,3 +22,11 @@ http_archive(
 )
 load("@rules_python//python:repositories.bzl", "py_repositories")
 py_repositories()
+
+http_archive(
+    name = "rules_pkg",
+    url = "https://github.com/bazelbuild/rules_pkg/releases/download/0.2.5/rules_pkg-0.2.5.tar.gz",
+    sha256 = "352c090cc3d3f9a6b4e676cf42a6047c16824959b438895a76c2989c6d7c246a",
+)
+load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
+rules_pkg_dependencies()

--- a/fuzzing/cc_deps.bzl
+++ b/fuzzing/cc_deps.bzl
@@ -21,6 +21,7 @@ load("//fuzzing:common.bzl", "fuzzing_corpus", "fuzzing_launcher")
 
 def cc_fuzz_test(
         name,
+        corpus = [],
         **kwargs):
     """Macro for c++ fuzzing test
 
@@ -45,7 +46,7 @@ def cc_fuzz_test(
         testonly = True,
     )
 
-    if "corpus" in kwargs:
+    if corpus:
         fuzzing_corpus(
             name = name + "_corpus",
             srcs = kwargs["corpus"],

--- a/fuzzing/cc_deps.bzl
+++ b/fuzzing/cc_deps.bzl
@@ -16,6 +16,7 @@
 """This file contains basic functions for cc fuzz test."""
 
 load("@rules_cc//cc:defs.bzl", "cc_test")
+load("@rules_pkg//:pkg.bzl", "pkg_zip")
 load("//fuzzing:common.bzl", "fuzzing_corpus", "fuzzing_launcher")
 
 def cc_fuzz_test(
@@ -55,5 +56,9 @@ def cc_fuzz_test(
     if corpus:
         fuzzing_corpus(
             name = name + "_corpus",
+            srcs = corpus,
+        )
+        pkg_zip(
+            name = name + "_corpus_zip",
             srcs = corpus,
         )

--- a/fuzzing/cc_deps.bzl
+++ b/fuzzing/cc_deps.bzl
@@ -17,7 +17,6 @@
 
 load("@rules_cc//cc:defs.bzl", "cc_test")
 load("//fuzzing:common.bzl", "fuzzing_corpus", "fuzzing_launcher")
-load("@rules_pkg//:pkg.bzl", "pkg_zip")
 
 def cc_fuzz_test(
         name,

--- a/fuzzing/cc_deps.bzl
+++ b/fuzzing/cc_deps.bzl
@@ -21,7 +21,7 @@ load("//fuzzing:common.bzl", "fuzzing_corpus", "fuzzing_launcher")
 
 def cc_fuzz_test(
         name,
-        corpus = [],
+        corpus = None,
         **kwargs):
     """Macro for c++ fuzzing test
 
@@ -49,9 +49,9 @@ def cc_fuzz_test(
     if corpus:
         fuzzing_corpus(
             name = name + "_corpus",
-            srcs = kwargs["corpus"],
+            srcs = corpus,
         )
         pkg_zip(
             name = name + "_corpus_zip",
-            srcs = kwargs["corpus"],
+            srcs = corpus,
         )

--- a/fuzzing/cc_deps.bzl
+++ b/fuzzing/cc_deps.bzl
@@ -16,7 +16,8 @@
 """This file contains basic functions for cc fuzz test."""
 
 load("@rules_cc//cc:defs.bzl", "cc_test")
-load("//fuzzing:common.bzl", "fuzzing_launcher")
+load("//fuzzing:common.bzl", "fuzzing_corpus", "fuzzing_launcher")
+load("@rules_pkg//:pkg.bzl", "pkg_zip")
 
 def cc_fuzz_test(
         name,
@@ -25,8 +26,11 @@ def cc_fuzz_test(
         linkopts = [],
         deps = [],
         tags = [],
+        corpus = [],
         visibility = None):
-    """This macro provide two targets:
+    """Macro for c++ fuzzing test
+
+    This macro provide two targets:
     <name>: the executable file built by cc_test.
     <name>_run: an executable to launch the fuzz test.
 """
@@ -47,4 +51,18 @@ def cc_fuzz_test(
         # Since the script depends on the _fuzz_test above, which is a cc_test,
         # this attribute must be set.
         testonly = True,
+    )
+
+    if corpus:
+        fuzzing_corpus(
+            name = name + "_corpus",
+            srcs = corpus,
+        )
+
+    fuzzing_corpus(
+        name = name + "_corpus",
+        srcs = [
+            "f1.txt",
+            "ttt/f2.txt",
+        ],
     )

--- a/fuzzing/cc_deps.bzl
+++ b/fuzzing/cc_deps.bzl
@@ -58,11 +58,3 @@ def cc_fuzz_test(
             name = name + "_corpus",
             srcs = corpus,
         )
-
-    fuzzing_corpus(
-        name = name + "_corpus",
-        srcs = [
-            "f1.txt",
-            "ttt/f2.txt",
-        ],
-    )

--- a/fuzzing/common.bzl
+++ b/fuzzing/common.bzl
@@ -58,19 +58,23 @@ Rule for creating a script to run the fuzzing test
 )
 
 def _fuzzing_corpus_impl(ctx):
-    dir = ctx.actions.declare_directory(ctx.attr.name)
-    command = "cp "
+    corpus_dir = ctx.actions.declare_directory(ctx.attr.name)
+    cp_args = ctx.actions.args()
 
-    # Merge the file path to the cp command
-    for f in ctx.files.srcs:
-        command += f.short_path + " "
+    for input_file in ctx.files.srcs:
+        cp_args.add(input_file)
+
+    # Add destination to the arguments
+    cp_args.add(corpus_dir.path)
+
     ctx.actions.run_shell(
         inputs = ctx.files.srcs,
-        outputs = [dir],
-        command = command + dir.path,
+        outputs = [corpus_dir],
+        arguments = [cp_args],
+        command = "cp $@",
     )
 
-    return [DefaultInfo(files = depset([dir]))]
+    return [DefaultInfo(files = depset([corpus_dir]))]
 
 fuzzing_corpus = rule(
     implementation = _fuzzing_corpus_impl,

--- a/fuzzing/common.bzl
+++ b/fuzzing/common.bzl
@@ -76,8 +76,7 @@ fuzzing_corpus = rule(
     implementation = _fuzzing_corpus_impl,
     doc = """
 This rule provides a <name>_corpus directory collecting all the corpora files 
-specified in the corpus attribute of the cc_fuzz_test rule, 
-and a <name>_corpus.zip with the corpus files as a ZIP archive
+specified in the srcs attribute.
 """,
     attrs = {
         "srcs": attr.label_list(

--- a/fuzzing/common.bzl
+++ b/fuzzing/common.bzl
@@ -56,3 +56,33 @@ Rule for creating a script to run the fuzzing test
     },
     executable = True,
 )
+
+def _fuzzing_corpus_impl(ctx):
+    dir = ctx.actions.declare_directory(ctx.attr.name)
+    command = "cp "
+
+    # Merge the file path to the cp command
+    for f in ctx.files.srcs:
+        command += f.short_path + " "
+    ctx.actions.run_shell(
+        inputs = ctx.files.srcs,
+        outputs = [dir],
+        command = command + dir.path,
+    )
+
+    return [DefaultInfo(files = depset([dir]))]
+
+fuzzing_corpus = rule(
+    implementation = _fuzzing_corpus_impl,
+    doc = """
+This rule provides a <name>_corpus directory collecting all the corpora files 
+specified in the corpus attribute of the cc_fuzz_test rule, 
+and a <name>_corpus.zip with the corpus files as a ZIP archive
+""",
+    attrs = {
+        "srcs": attr.label_list(
+            doc = "The corpus files for the fuzzing test.",
+            allow_files = True,
+        ),
+    },
+)


### PR DESCRIPTION
**Commit Message:**
Rule fuzzing_corpus for collecting corpus files
**Additional Description:**
Example usage:

fuzzing_corpus(
    name = "my_fuzzer_corpus",
    srcs = [
        "file1.txt",
        "path/to/file2.txt",
    ],
)
**Testing:**
Local testing and CI testing
**Docs Changes:** N/A
**Fixes #12**

Signed-off-by: tengpeng <tengpeng.li2020@gmail.com>

	modified:   fuzzing/cc_deps.bzl
	modified:   fuzzing/common.bzl
