### PR TITLE
Use **kwargs to forward attributes in cc_fuzz_test

### DIFF
--- a/fuzzing/cc_deps.bzl
+++ b/fuzzing/cc_deps.bzl
@@ -23,7 +23,7 @@ def cc_fuzz_test(
         **kwargs):
     """Macro for c++ fuzzing test
 
-    This macro provide two targets:
+    This macro provides two targets:
     <name>: the executable file built by cc_test.
     <name>_run: an executable to launch the fuzz test.
 """

--- a/fuzzing/cc_deps.bzl
+++ b/fuzzing/cc_deps.bzl
@@ -21,8 +21,7 @@ load("//fuzzing:common.bzl", "fuzzing_launcher")
 def cc_fuzz_test(
         name,
         srcs,
-        **kwargs,
-        ):
+        **kwargs):
     """Macro for c++ fuzzing test
 
     This macro provide two targets:
@@ -32,12 +31,11 @@ def cc_fuzz_test(
 
     # Add fuzz_test tag
     kwargs["tags"] = ["fuzz_test"] + (kwargs["tags"] if "tags" in kwargs else [])
-    print(name, kwargs)
 
     cc_test(
         name = name,
         srcs = srcs,
-        **kwargs,
+        **kwargs
     )
 
     fuzzing_launcher(

--- a/fuzzing/cc_deps.bzl
+++ b/fuzzing/cc_deps.bzl
@@ -20,7 +20,6 @@ load("//fuzzing:common.bzl", "fuzzing_launcher")
 
 def cc_fuzz_test(
         name,
-        srcs,
         **kwargs):
     """Macro for c++ fuzzing test
 
@@ -30,11 +29,10 @@ def cc_fuzz_test(
 """
 
     # Add fuzz_test tag
-    kwargs["tags"] = ["fuzz_test"] + (kwargs["tags"] if "tags" in kwargs else [])
+    kwargs.setdefault("tags", []).append("fuzz_test")
 
     cc_test(
         name = name,
-        srcs = srcs,
         **kwargs
     )
 

--- a/fuzzing/cc_deps.bzl
+++ b/fuzzing/cc_deps.bzl
@@ -21,24 +21,23 @@ load("//fuzzing:common.bzl", "fuzzing_launcher")
 def cc_fuzz_test(
         name,
         srcs,
-        copts = [],
-        linkopts = [],
-        deps = [],
-        tags = [],
-        visibility = None):
-    """This macro provide two targets:
+        **kwargs,
+        ):
+    """Macro for c++ fuzzing test
+
+    This macro provide two targets:
     <name>: the executable file built by cc_test.
     <name>_run: an executable to launch the fuzz test.
 """
 
+    # Add fuzz_test tag
+    kwargs["tags"] = ["fuzz_test"] + (kwargs["tags"] if "tags" in kwargs else [])
+    print(name, kwargs)
+
     cc_test(
         name = name,
         srcs = srcs,
-        copts = ["-fsanitize=fuzzer"] + copts,
-        linkopts = ["-fsanitize=fuzzer"] + linkopts,
-        deps = deps,
-        tags = tags + ["fuzz_test"],
-        visibility = visibility,
+        **kwargs,
     )
 
     fuzzing_launcher(


### PR DESCRIPTION
**Commit Message:**
Forward all attributes that `cc_fuzz_test` can't handle to `cc_test` by
using keyword arguments `**kwargs`.
**Additional Description:**
Since `cc_test` doesn't accept `corpus` but we may pass `corpus` in `cc_fuzz_test`, we need to delete `corpus` entry in `**kwargs` after calling `launcher_corpus` in #38 
**Testing:**
Local testing and CI testing
**Docs Changes:** N/A
**Fixes #26**

Signed-off-by: tengpeng <tengpeng.li2020@gmail.com>

	modified:   fuzzing/cc_deps.bzl
