### PR TITLE
Explicitly use file.path in fuzzing_corpus

### DIFF
--- a/fuzzing/common.bzl
+++ b/fuzzing/common.bzl
@@ -69,7 +69,7 @@ def _fuzzing_corpus_impl(ctx):
     cp_args = ctx.actions.args()
 
     for input_file in ctx.files.srcs:
-        cp_args.add(input_file)
+        cp_args.add(input_file.path)
 
     # Add destination to the arguments
     cp_args.add(corpus_dir.path)


### PR DESCRIPTION
**Commit Message:**
Explicitly use file.path in fuzzing_corpus

There is a CI error in Envoy mentioned the input_file may be a
directory, which can't be added by ctx.actions.args.add. As a workaround,
the path of the file is added instead.

**Additional Description:**
The shell command `cp $@` can add a `-r` parameter to avoid the file is a directory, though I am not sure that matches the user's desire and our plan.
**Testing:**
Local testing and CI testing.
**Docs Changes:** N/A

Signed-off-by: tengpeng <tengpeng.li2020@gmail.com>

	modified:   fuzzing/common.bzl
