### PR TITLE
Adds dictionary support to launcher

### DIFF
--- a/examples/BUILD
+++ b/examples/BUILD
@@ -50,7 +50,10 @@ cc_fuzz_test(
     dicts = ["dict_dir/valid.dict"],
 )
 
-# Building and runing this target are expected to get an error message due to the invalid dictionary.
+# This target shows a fuzz test target with an invalid dictionary.
+# Building and runing empty_fuzz_test_with_invalid_dict should be ok,
+# but building and running empty_fuzz_test_with_invalid_dict_run are expected to get an error message
+# due to the invalid dictionary.
 cc_fuzz_test(
     name = "empty_fuzz_test_with_invalid_dict",
     srcs = ["empty_fuzz_test.cc"],

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -50,11 +50,11 @@ cc_fuzz_test(
     dicts = ["dict_dir/valid.dict"],
 )
 
-# This target is expect to fail due to the invalid dictionary
+# Building and runing this target are expected to get an error message due to the invalid dictionary,
 cc_fuzz_test(
     name = "empty_fuzz_test_with_invalid_dict",
     srcs = ["empty_fuzz_test.cc"],
-    dicts = glob(["dict_dir/**"]),
+    dicts = ["dict_dir/invalid.dict"],
 )
 
 cc_fuzz_test(

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -32,7 +32,7 @@ filegroup(
     srcs = ["corpus_1.txt"] + glob(["corpus_dir/**"]),
 )
 
-# This target shows how to create a fuzz test target with corpus files
+# This target shows how to create a fuzz test target with corpus files.
 cc_fuzz_test(
     name = "empty_fuzz_test_with_corpus",
     srcs = ["empty_fuzz_test.cc"],
@@ -43,14 +43,14 @@ cc_fuzz_test(
     ],
 )
 
-# This target shows how to create a fuzz test target with dictionaries
+# This target shows how to create a fuzz test target with dictionaries.
 cc_fuzz_test(
     name = "empty_fuzz_test_with_dict",
     srcs = ["empty_fuzz_test.cc"],
     dicts = ["dict_dir/valid.dict"],
 )
 
-# Building and runing this target are expected to get an error message due to the invalid dictionary,
+# Building and runing this target are expected to get an error message due to the invalid dictionary.
 cc_fuzz_test(
     name = "empty_fuzz_test_with_invalid_dict",
     srcs = ["empty_fuzz_test.cc"],
@@ -68,7 +68,7 @@ cc_fuzz_test(
     srcs = ["hang_fuzz_test.cc"],
 )
 
-# This test is designed to trigger an uninitialized memory issue
+# This test is designed to trigger an uninitialized memory issue.
 cc_fuzz_test(
     name = "msan_fuzz_test",
     srcs = ["msan_fuzz_test.cc"],

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -43,6 +43,20 @@ cc_fuzz_test(
     ],
 )
 
+# This target shows how to create a fuzz test target with dictionaries
+cc_fuzz_test(
+    name = "empty_fuzz_test_with_dict",
+    srcs = ["empty_fuzz_test.cc"],
+    dicts = ["dict_dir/valid.dict"],
+)
+
+# This target is expect to fail due to the invalid dictionary
+cc_fuzz_test(
+    name = "empty_fuzz_test_with_invalid_dict",
+    srcs = ["empty_fuzz_test.cc"],
+    dicts = glob(["dict_dir/**"]),
+)
+
 cc_fuzz_test(
     name = "fuzzed_data_provider_fuzz_test",
     srcs = ["fuzzed_data_provider_fuzz_test.cc"],

--- a/examples/dict_dir/invalid.dict
+++ b/examples/dict_dir/invalid.dict
@@ -1,0 +1,3 @@
+Invalid dictionary entries
+"
+"\A"

--- a/examples/dict_dir/valid.dict
+++ b/examples/dict_dir/valid.dict
@@ -1,0 +1,28 @@
+# Dictionary from Enovy
+":path"
+":method"
+":scheme"
+":status"
+":authority"
+"host"
+"keep-alive"
+":protocol"
+"set-cookie"
+"upgrade"
+"via"
+"te"
+"user-agent"
+"content-length"
+"chunked"
+"transfer-encoding"
+# Lines starting with '#' and empty lines are ignored.
+
+# Adds "blah" (w/o quotes) to the dictionary.
+kw1="blah"
+# Use \\ for backslash and \" for quotes.
+kw2="\"ac\\dc\""
+# Use \xAB for hex values
+kw3="\xF7\xF8""
+# the name of the keyword followed by '=' may be omitted:
+"foo\x0Abar"
+"ab""

--- a/fuzzing/cc_deps.bzl
+++ b/fuzzing/cc_deps.bzl
@@ -17,11 +17,12 @@
 
 load("@rules_cc//cc:defs.bzl", "cc_test")
 load("@rules_pkg//:pkg.bzl", "pkg_zip")
-load("//fuzzing:common.bzl", "fuzzing_corpus", "fuzzing_launcher")
+load("//fuzzing:common.bzl", "fuzzing_corpus", "fuzzing_dictionary", "fuzzing_launcher")
 
 def cc_fuzz_test(
         name,
         corpus = None,
+        dicts = None,
         **kwargs):
     """Macro for c++ fuzzing test
 
@@ -47,11 +48,18 @@ def cc_fuzz_test(
             name = name + "_corpus_zip",
             srcs = [name + "_corpus"],
         )
+    if dicts:
+        fuzzing_dictionary(
+            name = name + "_dict",
+            dicts = dicts,
+            output = name + ".dict",
+        )
 
     fuzzing_launcher(
         name = name + "_run",
         target = name,
         corpus = name + "_corpus" if corpus else None,
+        dict = name + "_dict" if dicts else None,
         is_regression = False,
         # Since the script depends on the _fuzz_test above, which is a cc_test,
         # this attribute must be set.

--- a/fuzzing/common.bzl
+++ b/fuzzing/common.bzl
@@ -24,6 +24,7 @@ def _fuzzing_launcher_impl(ctx):
         ctx.executable._launcher.short_path,
         ctx.executable.target.short_path,
         "--corpus_dir=" + ctx.file.corpus.short_path if ctx.attr.corpus else "",
+        "--dict=" + ctx.file.dict.short_path if ctx.attr.dict else "",
         "--engine=" + ctx.attr._engine[BuildSettingInfo].value,
     ]
 
@@ -43,6 +44,8 @@ exec {launcher_args} "$@" """
     runfiles = runfiles.merge(ctx.attr.target[DefaultInfo].default_runfiles)
     if ctx.attr.corpus:
         runfiles = runfiles.merge(ctx.attr.corpus[DefaultInfo].default_runfiles)
+    if ctx.attr.dict:
+        runfiles = runfiles.merge(ctx.attr.dict[DefaultInfo].default_runfiles)
 
     return [DefaultInfo(executable = script, runfiles = runfiles)]
 
@@ -71,6 +74,10 @@ Rule for creating a script to run the fuzzing test.
         ),
         "corpus": attr.label(
             doc = "The target to create a directory containing corpus files.",
+            allow_single_file = True,
+        ),
+        "dict": attr.label(
+            doc = "The target to validate and merge the dictionaries.",
             allow_single_file = True,
         ),
         "is_regression": attr.bool(
@@ -133,7 +140,6 @@ def _fuzzing_dictionary_impl(ctx):
     )
 
     runfiles = ctx.runfiles(files = [output_dict])
-    runfiles.merge(ctx.attr._validation_tool[DefaultInfo].default_runfiles)
 
     return [DefaultInfo(
         runfiles = runfiles,

--- a/fuzzing/tools/launcher.py
+++ b/fuzzing/tools/launcher.py
@@ -25,6 +25,14 @@ import os
 
 FLAGS = flags.FLAGS
 
+flags.DEFINE_bool(
+    "regression", False,
+    "If set True, the script will trigger the target as a regression test.")
+
+flags.DEFINE_enum(
+    "engine", "default", ["default", "libfuzzer"],
+    "The type of the engine, the default is to run a gUnit test.")
+
 flags.DEFINE_integer(
     "timeout_secs",
     20,
@@ -36,13 +44,8 @@ flags.DEFINE_string(
     "If non-empty, a directory that will be used as a seed corpus for the fuzzer run."
 )
 
-flags.DEFINE_enum(
-    "engine", "default", ["default", "libfuzzer"],
-    "The type of the engine, the default is to run a gUnit test.")
-
-flags.DEFINE_bool(
-    "regression", False,
-    "If set True, the script will trigger the target as a regression test.")
+flags.DEFINE_string("dict", "",
+                    "If non-empty, a dictionary file of input keywords.")
 
 
 def main(argv):
@@ -57,6 +60,8 @@ def main(argv):
         command_args.append("-timeout=" + str(FLAGS.timeout_secs))
         if FLAGS.regression:
             command_args.append("-runs=0")
+        if FLAGS.dict:
+            command_args.append("-dict=" + FLAGS.dict)
     if FLAGS.corpus_dir:
         command_args.append(FLAGS.corpus_dir)
     os.execv(argv[1], command_args)


### PR DESCRIPTION
**Commit Message:**
1) Adds --dict to launcher.py
2) Adds fuzzing_dictionary as an implicit argument to fuzzing_launcher
3) Adds dict_dir directory with valid and invalid dictionaries
4) Adds empty_fuzz_test_with_dict and empty_fuzz_test_with_invalid_dict

**Additional Description:**
The second issue described in #43 is not clear to me yet, waiting to fix.
**Testing:**
Local testing and CI testing
**Docs Changes:** N/A
**Fixes #43**


Signed-off-by: tengpeng <tengpeng.li2020@gmail.com>

	modified:   examples/BUILD
	new file:   examples/dict_dir/invalid.dict
	new file:   examples/dict_dir/valid.dict
	modified:   fuzzing/cc_deps.bzl
	modified:   fuzzing/common.bzl
	modified:   fuzzing/tools/launcher.py