### PR TITLE
Deletes is_regression parameter in fuzzing_launcher

### DIFF
--- a/fuzzing/cc_deps.bzl
+++ b/fuzzing/cc_deps.bzl
@@ -35,6 +35,7 @@ def cc_fuzz_test(
     Args:
         name: a unique name for this target.
         corpus: a list containing corpus files.
+        dicts: a list containing dictionaries.
         **kwargs: keyword arguments.
     """
 
@@ -67,7 +68,6 @@ def cc_fuzz_test(
         target = name,
         corpus = name + "_corpus" if corpus else None,
         dict = name + "_dict" if dicts else None,
-        is_regression = False,
         # Since the script depends on the _fuzz_test above, which is a cc_test,
         # this attribute must be set.
         testonly = True,

--- a/fuzzing/common.bzl
+++ b/fuzzing/common.bzl
@@ -28,9 +28,6 @@ def _fuzzing_launcher_impl(ctx):
         "--engine=" + ctx.attr._engine[BuildSettingInfo].value,
     ]
 
-    if ctx.attr.is_regression:
-        args.append("--regression=True")
-
     script_template = """#!/bin/sh
 exec {launcher_args} "$@" """
 
@@ -79,10 +76,6 @@ Rule for creating a script to run the fuzzing test.
         "dict": attr.label(
             doc = "The target to validate and merge the dictionaries.",
             allow_single_file = True,
-        ),
-        "is_regression": attr.bool(
-            doc = "If set true the target is for a regression test.",
-            default = True,
         ),
     },
     executable = True,

--- a/fuzzing/tools/launcher.py
+++ b/fuzzing/tools/launcher.py
@@ -35,7 +35,7 @@ flags.DEFINE_enum(
 
 flags.DEFINE_integer(
     "timeout_secs",
-    20,
+    0,
     "The maximum duration, in seconds, of the fuzzer run launched.",
     lower_bound=0)
 


### PR DESCRIPTION
**Commit Message:**
Deletes is_regression parameter in fuzzing_launcher.
**Additional Description:**
After deleting this parameter, the user can't set the launcher for regression test directly, instead the user can set it in the command or a shell script.

This change comes from the discussion in https://github.com/envoyproxy/envoy/pull/12530#discussion_r476725983

**Testing:**
Local testing and CI testing.
**Docs Changes:** N/A
