### PR TITLE
Adds optional_args to launcher.py

### DIFF
--- a/fuzzing/tools/launcher.py
+++ b/fuzzing/tools/launcher.py
@@ -39,9 +39,13 @@ flags.DEFINE_integer(
     "The maximum duration, in seconds, of the fuzzer run launched.",
     lower_bound=0)
 
+flags.DEFINE_list(
+    "optional_args", None,
+    "If non-empty, the elements will be passed to the fuzzer as arguments.")
+
 flags.DEFINE_string(
     "corpus_dir", "",
-    "If non-empty, a directory that will be used as a seed corpus for the fuzzer run."
+    "If non-empty, a directory that will be used as a seed corpus for the fuzzer."
 )
 
 flags.DEFINE_string("dict", "",
@@ -64,6 +68,8 @@ def main(argv):
             command_args.append("-dict=" + FLAGS.dict)
     if FLAGS.corpus_dir:
         command_args.append(FLAGS.corpus_dir)
+    if FLAGS.optional_args:
+        command_args.extend(FLAGS.optional_args)
     os.execv(argv[1], command_args)
 
 

--- a/fuzzing/tools/launcher.py
+++ b/fuzzing/tools/launcher.py
@@ -40,7 +40,7 @@ flags.DEFINE_integer(
     lower_bound=0)
 
 flags.DEFINE_list(
-    "optional_args", None,
+    "fuzzer_extra_args", None,
     "If non-empty, the elements will be passed to the fuzzer as arguments.")
 
 flags.DEFINE_string(
@@ -68,8 +68,8 @@ def main(argv):
             command_args.append("-dict=" + FLAGS.dict)
     if FLAGS.corpus_dir:
         command_args.append(FLAGS.corpus_dir)
-    if FLAGS.optional_args:
-        command_args.extend(FLAGS.optional_args)
+    if FLAGS.fuzzer_extra_args:
+        command_args.extend(FLAGS.fuzzer_extra_args)
     os.execv(argv[1], command_args)
 
 


### PR DESCRIPTION
**Commit Message:**
The launcher script wraps the original fuzzing binary, to let user pass
the optional arguments to the fuzzing binary, a list argument
optional_args is added to the launcher.py.

**Additional Description:**
**Testing:**
Local testing and CI testing.
**Docs Changes:** N/A

Signed-off-by: tengpeng <tengpeng.li2020@gmail.com>

	modified:   fuzzing/tools/launcher.py
